### PR TITLE
Pin `sinter>=1.12.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [
     "stim",
-    "sinter",
+    "sinter<1.14.0",
     "ldpc ~= 0.1",
     "numpy"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [
     "stim",
-    "sinter<1.14.0",
+    "sinter>=1.12.0,<1.14.0",
     "ldpc ~= 0.1",
     "numpy"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [
     "stim",
-    "sinter>=1.12.0,<1.14.0",
+    "sinter>=1.12.0",
     "ldpc ~= 0.1",
     "numpy"
 ]


### PR DESCRIPTION
Closes #4


✅ `uvx --with stimbposd --with "sinter==1.12.0" python -c "from stimbposd import SinterDecoder_BPOSD"` 
✅ `uvx --with stimbposd --with "sinter==1.14.0" python -c "from stimbposd import SinterDecoder_BPOSD"` 
❌ `uvx --with stimbposd --with "sinter==1.11.0" python -c "from stimbposd import SinterDecoder_BPOSD"` 
