### PR TITLE
Support both ldpc versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ requires-python = ">=3.7"
 dependencies = [
     "stim",
     "sinter",
-    "ldpc ~= 0.1",
+    "ldpc",
     "numpy"
 ]
 classifiers = [

--- a/src/stimbposd/bp_osd.py
+++ b/src/stimbposd/bp_osd.py
@@ -1,4 +1,4 @@
-from ldpc.osd import bposd_decoder
+from ldpc.bposd_decoder import BpOsdDecoder
 import numpy as np
 from stimbposd.dem_to_matrices import detector_error_model_to_check_matrices
 
@@ -49,11 +49,11 @@ class BPOSD:
         self.num_errors = model.num_errors
         h_shape = self._matrices.check_matrix.shape
         max_osd_order = h_shape[1] - h_shape[0]
-        self._bposd = bposd_decoder(
-            parity_check_matrix=self._matrices.check_matrix,
+        self._bposd = BpOsdDecoder(
+            pcm=self._matrices.check_matrix,
             max_iter=max_bp_iters,
             bp_method=bp_method,
-            channel_probs=self._matrices.priors,
+            error_channel=list(self._matrices.priors),
             osd_order=min(osd_order, max_osd_order),
             osd_method=osd_method,
             input_vector_type="syndrome",

--- a/src/stimbposd/bp_osd.py
+++ b/src/stimbposd/bp_osd.py
@@ -1,6 +1,22 @@
-from ldpc.bposd_decoder import BpOsdDecoder
 import numpy as np
 from stimbposd.dem_to_matrices import detector_error_model_to_check_matrices
+
+try:
+    from ldpc.bposd_decoder import BpOsdDecoder
+    def create_decoder(pcm, priors, **kwargs):
+        return BpOsdDecoder(
+            pcm=pcm,
+            error_channel=list(priors),
+            **kwargs
+        )
+except ImportError:
+    from ldpc.osd import bposd_decoder
+    def create_decoder(pcm, priors, **kwargs):
+        return bposd_decoder(
+            parity_check_matrix=pcm,
+            channel_probs=priors,
+            **kwargs
+        )
 
 import stim
 
@@ -49,11 +65,11 @@ class BPOSD:
         self.num_errors = model.num_errors
         h_shape = self._matrices.check_matrix.shape
         max_osd_order = h_shape[1] - h_shape[0]
-        self._bposd = BpOsdDecoder(
+        self._bposd = create_decoder(
             pcm=self._matrices.check_matrix,
             max_iter=max_bp_iters,
             bp_method=bp_method,
-            error_channel=list(self._matrices.priors),
+            priors=self._matrices.priors,
             osd_order=min(osd_order, max_osd_order),
             osd_method=osd_method,
             input_vector_type="syndrome",


### PR DESCRIPTION
Fix #3 - Add compatibility with ldpc-v2.

I followed @lucasberent's approach, but running it on the [example script](https://github.com/oscarhiggott/stimbposd/blob/main/examples/surface_code_threshold.py) I noticed it has some speed degradation [of about 20%](https://github.com/quantumgizmos/ldpc/issues/67). Still, supporting v2 is important since there are other libraries that depend on `ldpc-v2`, leading to dependency conflicts.

So, I added support for both v1 and v2.

## Tests

✅ `python -m pytest tests`
✅ `uvx --with stimbposd --with "sinter>=1.12" --with "ldpc~=0.1" python -c "from stimbposd import BPOSD"`
✅ `uvx --with stimbposd --with "sinter>=1.12" --with "ldpc~=2.3" python -c "from stimbposd import BPOSD"`
