### PR TITLE
Fix OSD order ValueError for overconstrained detector error models

### DIFF
--- a/examples/five_qubit_code.py
+++ b/examples/five_qubit_code.py
@@ -1,0 +1,144 @@
+"""[[5,1,3]] perfect code — logical error rate vs physical error rate with BP+OSD.
+
+The five-qubit perfect code encodes 1 logical qubit into 5 physical qubits and can
+correct any single-qubit error. This script constructs a syndrome-extraction circuit
+for the code, decodes shot data using stimbposd.BPOSD, and plots the logical error
+rate as a function of the physical error rate for several numbers of syndrome rounds.
+
+Usage:
+    python five_qubit_code.py
+
+Requires: stim, stimbposd, numpy, matplotlib, tqdm
+"""
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import stim
+import tqdm
+
+from stimbposd import BPOSD
+
+EXAMPLES_DIR = Path(__file__).resolve().parent
+
+
+def build_five_qubit_circuit(
+    rounds: int,
+    p_gate: float = 0.0,
+    p_meas: float = 0.0,
+    p_idle: float = 0.0,
+) -> stim.Circuit:
+    """Build a [[5,1,3]] syndrome-extraction circuit with depolarising noise.
+
+    Uses 9 qubits: data qubits 0-4 and ancilla qubits 5-8. The four weight-4
+    stabiliser generators are:
+        g0 = IXZZX   g1 = XIXZZ   g2 = ZXIXZ   g3 = ZZXIX
+
+    Each generator is measured by conjugating the ancilla with H, then applying
+    CX (for X-type) and CZ (for Z-type) interactions, then measuring.
+
+    Parameters
+    ----------
+    rounds : int
+        Number of noisy syndrome rounds.
+    p_gate : float
+        Single- and two-qubit gate depolarising error rate.
+    p_meas : float
+        Measurement flip probability.
+    p_idle : float
+        Idle data-qubit depolarising error rate per syndrome round.
+    """
+    code = stim.Circuit()
+    data = list(range(5))
+    anc = list(range(5, 9))
+
+    for i in range(5):
+        code.append("QUBIT_COORDS", i, [0, i])
+    for i in range(4):
+        code.append("QUBIT_COORDS", i + 5, [2, 0.5 + i])
+
+    def stabilizer_cycle(pg: float, pm: float, pi: float) -> stim.Circuit:
+        c = stim.Circuit()
+        c.append("H", anc)
+        if pg > 0:
+            c.append("DEPOLARIZE1", anc, pg)
+        c.append("TICK")
+        for i in range(4):
+            # X-type interactions (via CX): qubits i and (i+3) mod 5
+            c.append("CX", [anc[i], data[i % 5], anc[i], data[(i + 3) % 5]])
+            if pg > 0:
+                c.append("DEPOLARIZE2", [anc[i], data[i % 5], anc[i], data[(i + 3) % 5]], pg)
+            # Z-type interactions (via CZ): qubits (i+1) and (i+2) mod 5
+            c.append("CZ", [anc[i], data[(i + 1) % 5], anc[i], data[(i + 2) % 5]])
+            if pg > 0:
+                c.append("DEPOLARIZE2", [anc[i], data[(i + 1) % 5], anc[i], data[(i + 2) % 5]], pg)
+            c.append("TICK")
+        c.append("H", anc)
+        if pg > 0:
+            c.append("DEPOLARIZE1", anc, pg)
+        if pi > 0:
+            c.append("DEPOLARIZE1", data, pi)
+        c.append("MR", anc, pm)
+        return c
+
+    # Noiseless initialisation round to establish reference measurement values
+    code += stabilizer_cycle(0.0, 0.0, 0.0)
+    code.append("TICK")
+
+    noisy = stabilizer_cycle(p_gate, p_meas, p_idle)
+    for i in range(4):
+        noisy.append("DETECTOR", [stim.target_rec(-1 - i), stim.target_rec(-5 - i)], [0.5 + i, 2])
+
+    code += rounds * noisy
+    code.append("M", data)
+    code.append("OBSERVABLE_INCLUDE", [stim.target_rec(-i) for i in range(1, 6)], 0)
+    return code
+
+
+def run_experiment(
+    rounds: int,
+    shots: int,
+    p: float,
+    seed: int = 0,
+) -> float:
+    """Return the logical error rate for one (rounds, p) operating point."""
+    code = build_five_qubit_circuit(rounds, p_gate=p, p_meas=p, p_idle=p)
+    dem = code.detector_error_model(decompose_errors=True)
+    decoder = BPOSD(dem, max_bp_iters=20, osd_order=5)
+    sampler = code.compile_detector_sampler(seed=seed)
+    det, obs = sampler.sample(shots=shots, separate_observables=True)
+    predictions = decoder.decode_batch(det)
+    return float(np.mean(np.any(predictions != obs, axis=1)))
+
+
+def main() -> None:
+    p_values = np.linspace(0.001, 0.12, 25)
+    rounds_list = [1, 3, 5]
+    shots = 20_000
+
+    fig, ax = plt.subplots(figsize=(7, 5))
+
+    for rounds in rounds_list:
+        p_logical = [
+            run_experiment(rounds, shots, p)
+            for p in tqdm.tqdm(p_values, desc=f"rounds={rounds}")
+        ]
+        ax.semilogy(p_values, p_logical, marker="o", markersize=3, label=f"rounds={rounds}")
+
+    ax.semilogy(p_values, p_values, "k--", label="p_L = p (break-even)")
+    ax.set_xlabel("Physical error rate p")
+    ax.set_ylabel("Logical error rate p_L")
+    ax.set_title("[[5,1,3]] perfect code — BP+OSD decoder")
+    ax.legend()
+    ax.grid(True, which="both", alpha=0.3)
+
+    out = EXAMPLES_DIR / "five_qubit_code_bposd.pdf"
+    plt.tight_layout()
+    plt.savefig(out)
+    print(f"Saved plot to {out}")
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/stimbposd/bp_osd.py
+++ b/src/stimbposd/bp_osd.py
@@ -65,7 +65,7 @@ class BPOSD:
             max_iter=max_bp_iters,
             bp_method=bp_method,
             priors=self._matrices.priors,
-            osd_order=min(osd_order, max_osd_order),
+            osd_order=max(0, min(osd_order, max_osd_order)),
             osd_method=osd_method,
             input_vector_type="syndrome",
             **bposd_kwargs,

--- a/tests/bp_osd_test.py
+++ b/tests/bp_osd_test.py
@@ -8,6 +8,63 @@ from sinter._decoding import sample_decode
 
 from stimbposd import BPOSD, SinterDecoder_BPOSD, sinter_decoders
 
+
+def _build_513_circuit(
+    rounds: int,
+    p_gate: float = 0.0,
+    p_meas: float = 0.0,
+    p_idle: float = 0.0,
+    p_idle_ideal: float = 0.0,
+) -> stim.Circuit:
+    """Build a [[5,1,3]] syndrome-extraction circuit.
+
+    9 qubits total: 5 data (0-4) and 4 ancilla (5-8).
+    Stabilizers: IXZZX, XIXZZ, ZXIXZ, ZZXIX.
+    """
+    code = stim.Circuit()
+    data = list(range(5))
+    anc = list(range(5, 9))
+
+    for i in range(5):
+        code.append("QUBIT_COORDS", i, [0, i])
+    for i in range(4):
+        code.append("QUBIT_COORDS", i + 5, [2, 0.5 + i])
+
+    def stabilizer_cycle(pg: float, pm: float, pi: float) -> stim.Circuit:
+        c = stim.Circuit()
+        c.append("H", anc)
+        if pg > 0:
+            c.append("DEPOLARIZE1", anc, pg)
+        c.append("TICK")
+        for i in range(4):
+            c.append("CX", [anc[i], data[i % 5], anc[i], data[(i + 3) % 5]])
+            if pg > 0:
+                c.append("DEPOLARIZE2", [anc[i], data[i % 5], anc[i], data[(i + 3) % 5]], pg)
+            c.append("CZ", [anc[i], data[(i + 1) % 5], anc[i], data[(i + 2) % 5]])
+            if pg > 0:
+                c.append("DEPOLARIZE2", [anc[i], data[(i + 1) % 5], anc[i], data[(i + 2) % 5]], pg)
+            c.append("TICK")
+        c.append("H", anc)
+        if pg > 0:
+            c.append("DEPOLARIZE1", anc, pg)
+        c.append("MR", anc, pm)
+        return c
+
+    # Noiseless initialisation round
+    code += stabilizer_cycle(0.0, 0.0, 0.0)
+    code.append("TICK")
+
+    noisy = stabilizer_cycle(p_gate, p_meas, p_idle)
+    for i in range(4):
+        noisy.append("DETECTOR", [stim.target_rec(-1 - i), stim.target_rec(-5 - i)], [0.5 + i, 2])
+
+    if p_idle_ideal > 0:
+        code.append("DEPOLARIZE1", data, p_idle_ideal)
+    code += rounds * noisy
+    code.append("M", data)
+    code.append("OBSERVABLE_INCLUDE", [stim.target_rec(-i) for i in range(1, 6)], 0)
+    return code
+
 TEST_DATA_DIR = Path(__file__).resolve().parent / "data"
 
 
@@ -83,3 +140,28 @@ def test_sinter_decode_bivariate_bicycle(
     assert result.discards == 0
     assert 0 <= result.errors <= 2
     assert result.shots == 20
+
+
+def test_bposd_overconstrained_dem():
+    """Regression test: BPOSD must not raise when check matrix has more rows than columns.
+
+    The [[5,1,3]] code with idle-only noise produces a DEM with 40 detectors but only
+    15 error mechanisms (5 data qubits x 3 Pauli errors), so max_osd_order = 15 - 40 = -25.
+    Before the fix, any positive osd_order was clipped to -25 and passed to LDPC, causing:
+      ValueError: ERROR: OSD order '-25' invalid. Please choose a positive integer.
+    The fix clamps to max(0, min(osd_order, max_osd_order)) so the effective order is 0.
+    """
+    rounds = 10
+    code = _build_513_circuit(rounds, p_idle_ideal=0.01)
+    dem = code.detector_error_model(decompose_errors=True)
+    # Verify this DEM is indeed overconstrained (more rows than columns)
+    from stimbposd.dem_to_matrices import detector_error_model_to_check_matrices
+    mats = detector_error_model_to_check_matrices(dem, allow_undecomposed_hyperedges=True)
+    rows, cols = mats.check_matrix.shape
+    assert cols < rows, f"Expected overconstrained DEM (cols={cols} < rows={rows})"
+    # Both construction and decoding must succeed without raising
+    matcher = BPOSD(dem, max_bp_iters=20, osd_order=5)
+    sampler = code.compile_detector_sampler(seed=0)
+    det, obs = sampler.sample(shots=100, separate_observables=True)
+    predictions = matcher.decode_batch(det)
+    assert predictions.shape == obs.shape


### PR DESCRIPTION
## Problem

When a detector error model has more detectors than error mechanisms
(e.g. the [[5,1,3]] code with 10 rounds and idle-only noise: 40 detectors, 15 errors),
`max_osd_order = cols - rows` is negative. The previous code:

    osd_order=min(osd_order, max_osd_order)

passed a negative value to LDPC's `BpOsdDecoder`, causing:

    ValueError: ERROR: OSD order '-25' invalid. Please choose a positive integer.

This affects any circuit where the noise model produces fewer error mechanisms
than detectors — including low-noise idle errors, single-Pauli channels, etc.
Even `osd_order=0` triggered the bug.

## Fix

One-line change in `bp_osd.py`:

    osd_order=max(0, min(osd_order, max_osd_order))

When the DEM is overconstrained, this clamps to OSD-0 (pure Gaussian
elimination on the BP result), which is the highest feasible order.

## Changes

- `src/stimbposd/bp_osd.py` — one-line fix
- `tests/bp_osd_test.py` — regression test `test_bposd_overconstrained_dem`
  using the [[5,1,3]] code with idle-only noise (the exact scenario that
  triggered the bug)
- `examples/five_qubit_code.py` — new standalone example showing logical
  error rate vs physical error rate for the [[5,1,3]] perfect code using BP+OSD

## Disclaimer

Co-Authored-By: Claude Sonnet 4.6