### PR TITLE
Fix OSD order ValueError for overconstrained and noiseless DEMs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    name: Build and publish Python distributions to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      # This permission is required for Trusted Publishers (OIDC)
+      id-token: write
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+
+    - name: Build binary wheel and source tarball
+      run: python -m build
+
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "stim",
     "sinter>=1.12.0",
     "ldpc",
-    "numpy<=2.2.6" # See: https://github.com/quantumlib/Stim/pull/965
+    "numpy"
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/src/stimbposd/bp_osd.py
+++ b/src/stimbposd/bp_osd.py
@@ -65,7 +65,7 @@ class BPOSD:
             max_iter=max_bp_iters,
             bp_method=bp_method,
             priors=self._matrices.priors,
-            osd_order=min(osd_order, max_osd_order),
+            osd_order=max(0, min(osd_order, max_osd_order)),
             osd_method=osd_method,
             input_vector_type="syndrome",
             **bposd_kwargs,

--- a/tests/bp_osd_test.py
+++ b/tests/bp_osd_test.py
@@ -83,3 +83,48 @@ def test_sinter_decode_bivariate_bicycle(
     assert result.discards == 0
     assert 0 <= result.errors <= 2
     assert result.shots == 20
+
+
+def test_noiseless_circuit():
+    test_circ = stim.Circuit.generated(
+        "repetition_code:memory",
+        rounds=25,
+        distance=9,
+        before_round_data_depolarization=0,
+        before_measure_flip_probability=0,
+    )
+    bposd = BPOSD(test_circ.detector_error_model(), max_bp_iters=20)
+
+    # Test single decode
+    syndrome = np.zeros(bposd.num_detectors, dtype=np.uint8)
+    prediction = bposd.decode(syndrome)
+    assert np.all(prediction == 0)
+    assert prediction.shape == (test_circ.num_observables,)
+
+    # Test batch decode
+    num_shots = 100
+    shots = np.zeros((num_shots, bposd.num_detectors), dtype=np.uint8)
+    predictions = bposd.decode_batch(shots)
+    assert np.all(predictions == 0)
+    assert predictions.shape == (num_shots, test_circ.num_observables)
+
+
+def test_sinter_decode_noiseless_repetition_code():
+    circuit = stim.Circuit.generated(
+        "repetition_code:memory",
+        rounds=3,
+        distance=3,
+        before_round_data_depolarization=0,
+        before_measure_flip_probability=0,
+    )
+    result = sample_decode(
+        circuit_obj=circuit,
+        circuit_path=None,
+        dem_obj=circuit.detector_error_model(decompose_errors=True),
+        dem_path=None,
+        num_shots=1000,
+        decoder="bposd",
+        custom_decoders={"bposd": SinterDecoder_BPOSD()},
+    )
+    assert result.errors == 0
+    assert result.shots == 1000


### PR DESCRIPTION
When a detector error model has more detectors than error mechanisms (e.g. overconstrained DEMs, or completely noiseless circuits), max_osd_order = cols - rows is negative. Passing a negative value to LDPC's BpOsdDecoder causes a ValueError.

We now clamp the OSD order to at least 0:
    osd_order=max(0, min(osd_order, max_osd_order))

This clamps to OSD-0 (pure Gaussian elimination on the BP result) when the DEM is overconstrained, which is the highest feasible order.

Also added regression tests for the completely noiseless case. Fixes issue #2 